### PR TITLE
chore: add custom LogRecord classes to avoid ignore

### DIFF
--- a/daiquiri/__init__.py
+++ b/daiquiri/__init__.py
@@ -15,7 +15,7 @@ import logging.config
 import logging.handlers
 import sys
 import traceback
-import types
+import types as _ptypes
 import typing
 
 from daiquiri import output
@@ -112,7 +112,7 @@ def setup(
         def logging_excepthook(
             exc_type: typing.Optional[typing.Type[BaseException]],
             value: typing.Optional[BaseException],
-            tb: typing.Optional[types.TracebackType],
+            tb: typing.Optional[_ptypes.TracebackType],
         ) -> None:
             program_logger.critical(
                 "".join(traceback.format_exception(exc_type, value, tb))

--- a/daiquiri/handlers.py
+++ b/daiquiri/handlers.py
@@ -28,6 +28,8 @@ except ImportError:
     syslog = None  # type: ignore[assignment]
 
 
+from daiquiri import types
+
 # This is a copy of the numerical constants from syslog.h. The
 # definition of these goes back at least 20 years, and is specifically
 # 3 bits in a packed field, so these aren't likely to ever need
@@ -96,7 +98,8 @@ class JournalHandler(logging.Handler):
             extras["EXCEPTION_INFO"] = record.exc_info
 
         if hasattr(record, "_daiquiri_extra_keys"):
-            for k in record._daiquiri_extra_keys:  # type: ignore[attr-defined]
+            record = typing.cast(types.ExtrasLogRecord, record)
+            for k in record._daiquiri_extra_keys:
                 if k != "_daiquiri_extra_keys":
                     extras[k.upper()] = getattr(record, k)
 
@@ -113,16 +116,17 @@ class TTYDetectorStreamHandler(_TTYDetectorStreamHandlerBase):
     """Stream handler that adds a hint in the record if the stream is a TTY."""
 
     def format(self, record: logging.LogRecord) -> str:
+        record = typing.cast(types.TTYDetectionLogRecord, record)
         if hasattr(self.stream, "isatty"):
             try:
-                record._stream_is_a_tty = self.stream.isatty()  # type: ignore[attr-defined]
+                record._stream_is_a_tty = self.stream.isatty()
             except ValueError:
                 # Stream has been closed, usually during interpretor shutdown
-                record._stream_is_a_tty = False  # type: ignore[attr-defined]
+                record._stream_is_a_tty = False
         else:
-            record._stream_is_a_tty = False  # type: ignore[attr-defined]
+            record._stream_is_a_tty = False
         s = super(TTYDetectorStreamHandler, self).format(record)
-        del record._stream_is_a_tty  # type: ignore[attr-defined]
+        del record._stream_is_a_tty
         return s
 
 

--- a/daiquiri/types.py
+++ b/daiquiri/types.py
@@ -1,0 +1,18 @@
+import logging
+import typing
+
+
+class ColoredLogRecord(logging.LogRecord):
+    color: str
+    color_stop: str
+
+
+class ExtrasLogRecord(logging.LogRecord):
+    extras_prefix: str
+    extras_suffix: str
+    extras: str
+    _daiquiri_extra_keys: typing.Set[str]
+
+
+class TTYDetectionLogRecord(logging.LogRecord):
+    _stream_is_a_tty: bool


### PR DESCRIPTION
This relies on casting things, but it's a little bit better.