### PR TITLE
Use sphinx-build command to generate doc

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,4 +37,4 @@ ignore = E203,E501,W503,E231,A003,D101,D102,D103,D104,D105,D107,A003,D100
 
 [testenv:docs]
 deps = sphinx
-commands = python setup.py build_sphinx
+commands = sphinx-build -b html doc/source doc/build/html


### PR DESCRIPTION
Sphinx 7 has removed the setuptools integration sphinx-doc/sphinx#11363 
setup.py has been long deprecated and projects are encouraged to migrate away from using it.