### PR TITLE
Update typing for level during setup

### DIFF
--- a/daiquiri/__init__.py
+++ b/daiquiri/__init__.py
@@ -74,7 +74,7 @@ def getLogger(
 
 
 def setup(
-    level: int = logging.WARNING,
+    level: typing.Union[int, str] = logging.WARNING,
     outputs: typing.Iterable[typing.Union[output.Output, str]] = [output.STDERR],
     program_name: typing.Optional[str] = None,
     capture_warnings: bool = True,


### PR DESCRIPTION
When setting up daiquiri, daiquiri will work perfectly fine if you provide a valid string for log_level, e.g. "DEBUG", just as in the following example code:
```python
import daiquiri

daiquiri.setup(level="DEBUG")
```

However, typing tools such as mypy or pylance will complain, because the typing defined is that it must conform to the level being an `int`.

Looking at the nested code, for logging, when setting the level it does the following check:

```python
_nameToLevel = {
    'CRITICAL': CRITICAL,
    'FATAL': FATAL,
    'ERROR': ERROR,
    'WARN': WARNING,
    'WARNING': WARNING,
    'INFO': INFO,
    'DEBUG': DEBUG,
    'NOTSET': NOTSET,
}

def _checkLevel(level):
    if isinstance(level, int):
        rv = level
    elif str(level) == level:
        if level not in _nameToLevel:
            raise ValueError("Unknown level: %r" % level)
        rv = _nameToLevel[level]
    else:
        raise TypeError("Level not an integer or a valid string: %r"
                        % (level,))
    return rv
```

So in essence it does check that it is an int or a string that is a key in the dictionary _nameToLevel.

Proposing that we update the typing so that typing checking tools do not complain.

<!--

## Checklists (Just for information, delete me before creating the pull requests)

- [ ]  All checks must pass (Semantic Pull Request, pep8, requirements, unit tests, functional tests, security checks, …)
- [ ]  The code changed/added as part of this pull request must be covered with tests
- [ ]  Hotfixes must have a link to Sentry issue and the `hotfix` label
- [ ]  Features and fixes must have a link to a Linear task
- [ ]  Features must have changes in docs/
- [ ]  Features must have changes in releasenotes/notes/
- [ ]  User facing bug must have changed in releasenotes/nodes/
- [ ]  Pull request must have been reviewed by at least one core reviewer
- [ ]  No pending `requested changes`
- [ ]  No `unresolved threads`
- [ ]  Change that requires manual deployment steps or deployment monitoring requires `manual merge` label until the author is ready to do the deployment.

-->
