### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/daiquiri/handlers.py
+++ b/daiquiri/handlers.py
@@ -121,7 +121,7 @@ class TTYDetectorStreamHandler(_TTYDetectorStreamHandlerBase):
             try:
                 record._stream_is_a_tty = self.stream.isatty()
             except ValueError:
-                # Stream has been closed, usually during interpretor shutdown
+                # Stream has been closed, usually during interpreter shutdown
                 record._stream_is_a_tty = False
         else:
             record._stream_is_a_tty = False

--- a/daiquiri/output.py
+++ b/daiquiri/output.py
@@ -75,7 +75,7 @@ def _get_log_file_path(
 
 
 class File(Output):
-    """Ouput to a file."""
+    """Output to a file."""
 
     def __init__(
         self,
@@ -93,7 +93,7 @@ class File(Output):
 
         :param directory: The log directory to write to. If no filename is
                           specified, the program name and suffix will be used
-                          to contruct the full path relative to the directory.
+                          to construct the full path relative to the directory.
 
         :param suffix: The log file name suffix. This will be only used if no
                        filename has been provided.
@@ -129,7 +129,7 @@ class RotatingFile(Output):
 
         :param directory: The log directory to write to. If no filename is
                           specified, the program name and suffix will be used
-                          to contruct the full path relative to the directory.
+                          to construct the full path relative to the directory.
 
         :param suffix: The log file name suffix. This will be only used if no
                        filename has been provided.
@@ -179,7 +179,7 @@ class TimedRotatingFile(Output):
 
         :param directory: The log directory to write to. If no filename is
                           specified, the program name and suffix will be used
-                          to contruct the full path relative to the directory.
+                          to construct the full path relative to the directory.
 
         :param suffix: The log file name suffix. This will be only used if no
                        filename has been provided.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -55,7 +55,7 @@ Picking format
 --------------
 
 You can configure the format of any output by passing a formatter as the
-`formatter` argument to the contructor. Two default formatters are available:
+`formatter` argument to the constructor. Two default formatters are available:
 `daiquiri.formatter.TEXT_FORMATTER` which prints log messages as text, and the
 `daiquiri.formatter.JSON_FORMATTER` which prints log messages as parsable JSON
 (requires `python-json-logger`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,10 @@ module = [
        "systemd",
 ]
 ignore_missing_imports = true
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*'
+check-hidden = true
+ignore-regex = 'assertIn'
+# ignore-words-list = ''


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.