### PR TITLE
ci: fix Python 3.12 tests & linters

### DIFF
--- a/daiquiri/formatter.py
+++ b/daiquiri/formatter.py
@@ -157,9 +157,9 @@ class ColorExtrasFormatter(ColorFormatter, ExtrasFormatter):
         return s
 
 
-class DatadogFormatter(jsonlogger.JsonFormatter):
+class DatadogFormatter(jsonlogger.JsonFormatter):  # type: ignore[misc]
     def __init__(self) -> None:
-        super(DatadogFormatter, self).__init__(timestamp=True)  # type: ignore[no-untyped-call]
+        super(DatadogFormatter, self).__init__(timestamp=True)
 
     def add_fields(
         self,
@@ -183,5 +183,5 @@ class DatadogFormatter(jsonlogger.JsonFormatter):
 
 
 TEXT_FORMATTER = ColorExtrasFormatter(fmt=DEFAULT_EXTRAS_FORMAT)
-JSON_FORMATTER = jsonlogger.JsonFormatter()  # type: ignore[no-untyped-call]
+JSON_FORMATTER = jsonlogger.JsonFormatter()
 DATADOG_FORMATTER = DatadogFormatter()

--- a/daiquiri/tests/test_daiquiri.py
+++ b/daiquiri/tests/test_daiquiri.py
@@ -12,7 +12,6 @@
 import io
 import json
 import logging
-import sys
 import typing
 import unittest
 import warnings
@@ -42,8 +41,6 @@ class TestDaiquiri(unittest.TestCase):
         )
         daiquiri.getLogger(__name__).warning("foobar")
         expected: dict[str, typing.Any] = {"message": "foobar"}
-        if sys.version_info >= (3, 12):
-            expected.update({"taskName": None})
         self.assertEqual(expected, json.loads(stream.getvalue()))
 
     def test_setup_json_formatter_with_extras(self) -> None:
@@ -57,8 +54,6 @@ class TestDaiquiri(unittest.TestCase):
         )
         daiquiri.getLogger(__name__).warning("foobar", foo="bar")
         expected: dict[str, typing.Any] = {"message": "foobar", "foo": "bar"}
-        if sys.version_info >= (3, 12):
-            expected.update({"taskName": None})
         self.assertEqual(expected, json.loads(stream.getvalue()))
 
     def test_get_logger_set_level(self) -> None:
@@ -72,7 +67,7 @@ class TestDaiquiri(unittest.TestCase):
         line = stream.getvalue()
         self.assertIn("WARNING  py.warnings: ", line)
         self.assertIn(
-            "daiquiri/tests/test_daiquiri.py:71: "
+            "daiquiri/tests/test_daiquiri.py:66: "
             'UserWarning: omg!\n  warnings.warn("omg!")\n',
             line,
         )

--- a/daiquiri/tests/test_output.py
+++ b/daiquiri/tests/test_output.py
@@ -11,7 +11,6 @@
 #    under the License.
 import json
 import logging
-import sys
 import syslog
 import typing
 import unittest
@@ -125,10 +124,6 @@ class TestOutput(unittest.TestCase):
                     "message": mock.ANY,
                 },
             }
-            if sys.version_info >= (3, 12):
-                expected_error_1.update({"taskName": None})
-                expected_info_1.update({"taskName": None})
-                expected_error_2.update({"taskName": None})
             try:
                 1 / 0
             except ZeroDivisionError:

--- a/daiquiri/types.py
+++ b/daiquiri/types.py
@@ -1,3 +1,4 @@
+# flake8: noqa: A005
 import logging
 import typing
 


### PR DESCRIPTION
It seems taskName is no more included.
Also fixes some linters issues.