### PR TITLE
fix: don't break the monkeypatch chain

### DIFF
--- a/daiquiri/__init__.py
+++ b/daiquiri/__init__.py
@@ -109,14 +109,17 @@ def setup(
     if set_excepthook:
         program_logger = logging.getLogger(program_name)
 
+        initial_excepthook = staticmethod(sys.excepthook)
+
         def logging_excepthook(
-            exc_type: typing.Optional[typing.Type[BaseException]],
-            value: typing.Optional[BaseException],
+            exc_type: typing.Type[BaseException],
+            value: BaseException,
             tb: typing.Optional[_ptypes.TracebackType],
         ) -> None:
             program_logger.critical(
                 "".join(traceback.format_exception(exc_type, value, tb))
             )
+            initial_excepthook(exc_type, value, tb)
 
         sys.excepthook = logging_excepthook
 

--- a/daiquiri/tests/test_formatter.py
+++ b/daiquiri/tests/test_formatter.py
@@ -71,7 +71,7 @@ class TestColorExtrasFormatter(unittest.TestCase):
         )
 
     def test_keywords_no_extras(self) -> None:
-        format_string = "%(levelname)s %(name)s" " %(test)s%(extras)s: %(message)s"
+        format_string = "%(levelname)s %(name)s %(test)s%(extras)s: %(message)s"
         formatter = daiquiri.formatter.ColorExtrasFormatter(
             fmt=format_string, keywords={"test"}
         )
@@ -81,7 +81,7 @@ class TestColorExtrasFormatter(unittest.TestCase):
         self.assertEqual(self.stream.getvalue(), "INFO my_module a: test message\n")
 
     def test_keywords_with_extras(self) -> None:
-        format_string = "%(levelname)s %(name)s" " %(test)s%(extras)s: %(message)s"
+        format_string = "%(levelname)s %(name)s %(test)s%(extras)s: %(message)s"
         formatter = daiquiri.formatter.ColorExtrasFormatter(
             fmt=format_string, keywords={"test"}
         )


### PR DESCRIPTION
Mainly libs change this hook, a common practice is to run the existing
hook after or before the custom code.

This avoids breaking monkeypatching of other libs.