### PR TITLE
chore(dependabot): only rely on uv to avoid doubling PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,6 @@ updates:
       time: "09:00"
       timezone: Europe/Paris
     open-pull-requests-limit: 10
-  - package-ecosystem: pip
-    directory: "/"
-    schedule:
-      interval: daily
-      time: "09:00"
-      timezone: Europe/Paris
-    open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
It seems we have 2 PR for the same things otherwise, uv is enough.