### PR TITLE
build(deps-dev): bump ruff from 0.15.22 to 0.16.1

### DIFF
--- a/daiquiri/__init__.py
+++ b/daiquiri/__init__.py
@@ -43,7 +43,7 @@ class KeywordArgumentAdapter(_KeywordArgumentAdapterBase):
 
     def process(
         self, msg: typing.Any, kwargs: "collections.abc.MutableMapping[str, typing.Any]"
-    ) -> typing.Tuple[typing.Any, "collections.abc.MutableMapping[str, typing.Any]"]:
+    ) -> tuple[typing.Any, "collections.abc.MutableMapping[str, typing.Any]"]:
         # Make a new extra dictionary combining the values we were
         # given when we were constructed and anything from kwargs.
         if self.extra is not None:
@@ -61,9 +61,7 @@ class KeywordArgumentAdapter(_KeywordArgumentAdapterBase):
         return msg, kwargs
 
 
-def getLogger(
-    name: typing.Optional[str] = None, **kwargs: typing.Any
-) -> KeywordArgumentAdapter:
+def getLogger(name: str | None = None, **kwargs: typing.Any) -> KeywordArgumentAdapter:
     """Build a logger with the given name.
 
     :param name: The name for the logger. This is usually the module
@@ -74,9 +72,9 @@ def getLogger(
 
 
 def setup(
-    level: typing.Union[int, str] = logging.WARNING,
-    outputs: typing.Iterable[typing.Union[output.Output, str]] = [output.STDERR],
-    program_name: typing.Optional[str] = None,
+    level: int | str = logging.WARNING,
+    outputs: typing.Iterable[output.Output | str] = [output.STDERR],
+    program_name: str | None = None,
     capture_warnings: bool = True,
     set_excepthook: bool = True,
 ) -> None:
@@ -99,7 +97,7 @@ def setup(
     for out in outputs:
         if isinstance(out, str):
             if out not in output.preconfigured:
-                raise RuntimeError("Output {} is not available".format(out))
+                raise RuntimeError(f"Output {out} is not available")
             out = output.preconfigured[out]
 
         out.add_to_logger(root_logger)
@@ -112,9 +110,9 @@ def setup(
         initial_excepthook = staticmethod(sys.excepthook)
 
         def logging_excepthook(
-            exc_type: typing.Type[BaseException],
+            exc_type: type[BaseException],
             value: BaseException,
-            tb: typing.Optional[_ptypes.TracebackType],
+            tb: _ptypes.TracebackType | None,
         ) -> None:
             program_logger.critical(
                 "".join(traceback.format_exception(exc_type, value, tb))
@@ -139,15 +137,13 @@ def parse_and_set_default_log_levels(
     for pair in default_log_levels:
         result = pair.split(separator, 1)
         if len(result) != 2:
-            raise ValueError("Wrong log level format: `%s`" % result)
-        levels.append(typing.cast(typing.Tuple[str, str], tuple(result)))
+            raise ValueError(f"Wrong log level format: `{result}`")
+        levels.append(typing.cast(tuple[str, str], tuple(result)))
     return set_default_log_levels(levels)
 
 
 def set_default_log_levels(
-    loggers_and_log_levels: typing.Iterable[
-        typing.Tuple[typing.Optional[str], typing.Union[str, int]]
-    ],
+    loggers_and_log_levels: typing.Iterable[tuple[str | None, str | int]],
 ) -> None:
     """Set default log levels for some loggers.
 

--- a/daiquiri/formatter.py
+++ b/daiquiri/formatter.py
@@ -18,7 +18,6 @@ from pythonjsonlogger import json as jsonlogger
 
 from daiquiri import types
 
-
 DEFAULT_FORMAT = (
     "%(asctime)s [%(process)d] %(color)s%(levelname)-8.8s "
     "%(name)s: %(message)s%(color_stop)s"
@@ -34,10 +33,10 @@ class ColorFormatter(logging.Formatter):
     """Colorizes log output."""
 
     # TODO(jd) Allow configuration
-    LEVEL_COLORS = {
+    LEVEL_COLORS: typing.ClassVar[dict[int, str]] = {
         logging.DEBUG: "\033[00;32m",  # GREEN
         logging.INFO: "\033[00;36m",  # CYAN
-        logging.WARN: "\033[01;33m",  # BOLD YELLOW
+        logging.WARNING: "\033[01;33m",  # BOLD YELLOW
         logging.ERROR: "\033[01;31m",  # BOLD RED
         logging.CRITICAL: "\033[01;31m",  # BOLD RED
     }
@@ -62,7 +61,7 @@ class ColorFormatter(logging.Formatter):
         """Format a record."""
         record = typing.cast(types.ColoredLogRecord, record)
         self.add_color(record)
-        s = super(ColorFormatter, self).format(record)
+        s = super().format(record)
         self.remove_color(record)
         return s
 
@@ -106,7 +105,7 @@ class ExtrasFormatter(logging.Formatter):
 
     def __init__(
         self,
-        keywords: typing.Optional[typing.Set[str]] = None,
+        keywords: set[str] | None = None,
         extras_template: str = "[{0}: {1}]",
         extras_separator: str = " ",
         extras_prefix: str = " ",
@@ -119,7 +118,7 @@ class ExtrasFormatter(logging.Formatter):
         self.extras_separator = extras_separator
         self.extras_prefix = extras_prefix
         self.extras_suffix = extras_suffix
-        super(ExtrasFormatter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def add_extras(self, record: types.ExtrasLogRecord) -> None:
         if not hasattr(record, "_daiquiri_extra_keys"):
@@ -141,7 +140,7 @@ class ExtrasFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         record = typing.cast(types.ExtrasLogRecord, record)
         self.add_extras(record)
-        s = super(ExtrasFormatter, self).format(record)
+        s = super().format(record)
         self.remove_extras(record)
         return s
 
@@ -159,15 +158,15 @@ class ColorExtrasFormatter(ColorFormatter, ExtrasFormatter):
 
 class DatadogFormatter(jsonlogger.JsonFormatter):
     def __init__(self) -> None:
-        super(DatadogFormatter, self).__init__(timestamp=True)
+        super().__init__(timestamp=True)
 
     def add_fields(
         self,
-        log_record: typing.Dict[str, typing.Any],
+        log_record: dict[str, typing.Any],
         record: logging.LogRecord,
-        message_dict: typing.Dict[str, str],
+        message_dict: dict[str, str],
     ) -> None:
-        super(DatadogFormatter, self).add_fields(log_record, record, message_dict)
+        super().add_fields(log_record, record, message_dict)
         log_record["status"] = record.levelname.lower()
         log_record["logger"] = {
             "name": record.name,

--- a/daiquiri/handlers.py
+++ b/daiquiri/handlers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
 #    a copy of the License at
@@ -47,15 +46,13 @@ SYSLOG_MAP = {
 class SyslogHandler(logging.Handler):
     """Syslog based handler. Only available on UNIX-like platforms."""
 
-    def __init__(
-        self, program_name: str, facility: typing.Optional[int] = None
-    ) -> None:
+    def __init__(self, program_name: str, facility: int | None = None) -> None:
         # Default values always get evaluated, for which reason we avoid
         # using 'syslog' directly, which may not be available.
         facility = facility if facility is not None else syslog.LOG_USER
         if not syslog:
             raise RuntimeError("Syslog not available on this platform")
-        super(SyslogHandler, self).__init__()
+        super().__init__()
         syslog.openlog(program_name, 0, facility)
 
     def emit(self, record: logging.LogRecord) -> None:
@@ -72,7 +69,7 @@ class JournalHandler(logging.Handler):
     def __init__(self, program_name: str) -> None:
         if not journal:
             raise RuntimeError("Systemd bindings do not exist")
-        super(JournalHandler, self).__init__()
+        super().__init__()
         self.program_name = program_name
 
     def emit(self, record: logging.LogRecord) -> None:
@@ -125,7 +122,7 @@ class TTYDetectorStreamHandler(_TTYDetectorStreamHandlerBase):
                 record._stream_is_a_tty = False
         else:
             record._stream_is_a_tty = False
-        s = super(TTYDetectorStreamHandler, self).format(record)
+        s = super().format(record)
         del record._stream_is_a_tty
         return s
 
@@ -135,7 +132,7 @@ class PlainTextSocketHandler(logging.handlers.SocketHandler):
 
     def __init__(self, hostname: str, port: int, encoding: str = "utf-8") -> None:
         self.encoding = encoding
-        super(PlainTextSocketHandler, self).__init__(hostname, port)
+        super().__init__(hostname, port)
 
     def makePickle(self, record: logging.LogRecord) -> bytes:
         return self.format(record).encode(self.encoding) + b"\n"
@@ -146,7 +143,7 @@ class PlainTextDatagramHandler(logging.handlers.DatagramHandler):
 
     def __init__(self, hostname: str, port: int, encoding: str = "utf-8") -> None:
         self.encoding = encoding
-        super(PlainTextDatagramHandler, self).__init__(hostname, port)
+        super().__init__(hostname, port)
 
     def makePickle(self, record: logging.LogRecord) -> bytes:
         return self.format(record).encode(self.encoding) + b"\n"

--- a/daiquiri/output.py
+++ b/daiquiri/output.py
@@ -22,8 +22,7 @@ try:
 except ImportError:
     syslog = None  # type: ignore[assignment]
 
-from daiquiri import formatter
-from daiquiri import handlers
+from daiquiri import formatter, handlers
 
 
 def get_program_name() -> str:
@@ -38,7 +37,7 @@ class Output:
         self,
         handler: logging.Handler,
         formatter: logging.Formatter = formatter.TEXT_FORMATTER,
-        level: typing.Optional[int] = None,
+        level: int | None = None,
     ):
         self.handler = handler
         self.handler.setFormatter(formatter)
@@ -51,9 +50,9 @@ class Output:
 
 
 def _get_log_file_path(
-    logfile: typing.Optional[str] = None,
-    logdir: typing.Optional[str] = None,
-    program_name: typing.Optional[str] = None,
+    logfile: str | None = None,
+    logdir: str | None = None,
+    program_name: str | None = None,
     logfile_suffix: str = ".log",
 ) -> str:
     ret_path = None
@@ -79,12 +78,12 @@ class File(Output):
 
     def __init__(
         self,
-        filename: typing.Optional[str] = None,
-        directory: typing.Optional[str] = None,
+        filename: str | None = None,
+        directory: str | None = None,
         suffix: str = ".log",
-        program_name: typing.Optional[str] = None,
+        program_name: str | None = None,
         formatter: logging.Formatter = formatter.TEXT_FORMATTER,
-        level: typing.Optional[int] = None,
+        level: int | None = None,
     ):
         """Log file output.
 
@@ -103,7 +102,7 @@ class File(Output):
         """
         logpath = _get_log_file_path(filename, directory, program_name, suffix)
         handler = logging.handlers.WatchedFileHandler(logpath)
-        super(File, self).__init__(handler, formatter, level)
+        super().__init__(handler, formatter, level)
 
 
 class RotatingFile(Output):
@@ -113,12 +112,12 @@ class RotatingFile(Output):
 
     def __init__(
         self,
-        filename: typing.Optional[str] = None,
-        directory: typing.Optional[str] = None,
+        filename: str | None = None,
+        directory: str | None = None,
         suffix: str = ".log",
-        program_name: typing.Optional[str] = None,
+        program_name: str | None = None,
         formatter: logging.Formatter = formatter.TEXT_FORMATTER,
-        level: typing.Optional[int] = None,
+        level: int | None = None,
         max_size_bytes: int = 0,
         backup_count: int = 0,
     ):
@@ -147,7 +146,7 @@ class RotatingFile(Output):
         handler = logging.handlers.RotatingFileHandler(
             logpath, maxBytes=max_size_bytes, backupCount=backup_count
         )
-        super(RotatingFile, self).__init__(handler, formatter, level)
+        super().__init__(handler, formatter, level)
 
     def do_rollover(self) -> None:
         """Manually forces a log file rotation."""
@@ -161,15 +160,13 @@ class TimedRotatingFile(Output):
 
     def __init__(
         self,
-        filename: typing.Optional[str] = None,
-        directory: typing.Optional[str] = None,
+        filename: str | None = None,
+        directory: str | None = None,
         suffix: str = ".log",
-        program_name: typing.Optional[str] = None,
+        program_name: str | None = None,
         formatter: logging.Formatter = formatter.TEXT_FORMATTER,
-        level: typing.Optional[int] = None,
-        interval: typing.Union[float, int, datetime.timedelta] = datetime.timedelta(
-            hours=24
-        ),
+        level: int | None = None,
+        interval: float | datetime.timedelta = datetime.timedelta(hours=24),
         backup_count: int = 0,
     ):
         """Rotating log file output, triggered by a fixed interval.
@@ -199,7 +196,7 @@ class TimedRotatingFile(Output):
             interval=int(self._timedelta_to_seconds(interval)),
             backupCount=backup_count,
         )
-        super(TimedRotatingFile, self).__init__(handler, formatter, level)
+        super().__init__(handler, formatter, level)
 
     def do_rollover(self) -> None:
         """Manually forces a log file rotation."""
@@ -207,7 +204,7 @@ class TimedRotatingFile(Output):
 
     @staticmethod
     def _timedelta_to_seconds(
-        td: typing.Union[float, int, datetime.timedelta],
+        td: float | datetime.timedelta,
     ) -> float:
         """Convert a datetime.timedelta object into a seconds interval.
 
@@ -227,11 +224,9 @@ class Stream(Output):
         self,
         stream: typing.TextIO = sys.stderr,
         formatter: logging.Formatter = formatter.TEXT_FORMATTER,
-        level: typing.Optional[int] = None,
+        level: int | None = None,
     ) -> None:
-        super(Stream, self).__init__(
-            handlers.TTYDetectorStreamHandler(stream), formatter, level
-        )
+        super().__init__(handlers.TTYDetectorStreamHandler(stream), formatter, level)
 
 
 STDERR = Stream()
@@ -241,28 +236,26 @@ STDOUT = Stream(sys.stdout)
 class Journal(Output):
     def __init__(
         self,
-        program_name: typing.Optional[str] = None,
+        program_name: str | None = None,
         formatter: logging.Formatter = formatter.TEXT_FORMATTER,
-        level: typing.Optional[int] = None,
+        level: int | None = None,
     ) -> None:
         program_name = program_name or get_program_name()
-        super(Journal, self).__init__(
-            handlers.JournalHandler(program_name), formatter, level
-        )
+        super().__init__(handlers.JournalHandler(program_name), formatter, level)
 
 
 class Syslog(Output):
     def __init__(
         self,
-        program_name: typing.Optional[str] = None,
+        program_name: str | None = None,
         facility: str = "user",
         formatter: logging.Formatter = formatter.TEXT_FORMATTER,
-        level: typing.Optional[int] = None,
+        level: int | None = None,
     ) -> None:
         if syslog is None:
             # FIXME(jd) raise something more specific
             raise RuntimeError("syslog is not available on this platform")
-        super(Syslog, self).__init__(
+        super().__init__(
             handlers.SyslogHandler(
                 program_name=program_name or get_program_name(),
                 facility=self._find_facility(facility),
@@ -308,10 +301,8 @@ class Syslog(Output):
             facility = "LOG_" + facility
 
         if facility not in valid_facilities:
-            raise TypeError(
-                "syslog facility must be one of: %s"
-                % ", ".join("'%s'" % fac for fac in valid_facilities)
-            )
+            choices = ", ".join(f"'{fac}'" for fac in valid_facilities)
+            raise TypeError(f"syslog facility must be one of: {choices}")
 
         return int(getattr(syslog, facility))
 
@@ -322,12 +313,12 @@ class Datadog(Output):
         hostname: str = "127.0.0.1",
         port: int = 10518,
         formatter: logging.Formatter = formatter.DATADOG_FORMATTER,
-        level: typing.Optional[int] = None,
-        handler_class: typing.Type[
+        level: int | None = None,
+        handler_class: type[
             logging.handlers.SocketHandler
         ] = handlers.PlainTextSocketHandler,
     ):
-        super(Datadog, self).__init__(
+        super().__init__(
             handler_class(hostname, port),
             formatter=formatter,
             level=level,
@@ -335,7 +326,7 @@ class Datadog(Output):
 
 
 # FIXME(jd): Is this useful? Remove it?
-preconfigured: typing.Dict[str, typing.Union[Stream, Output]] = {
+preconfigured: dict[str, Stream | Output] = {
     "stderr": STDERR,
     "stdout": STDOUT,
 }

--- a/daiquiri/tests/test_daiquiri.py
+++ b/daiquiri/tests/test_daiquiri.py
@@ -29,7 +29,7 @@ class TestDaiquiri(unittest.TestCase):
         logging.captureWarnings(False)
         # Reset exception hook
         sys.excepthook = real_excepthook
-        super(TestDaiquiri, self).tearDown()
+        super().tearDown()
 
     def test_setup(self) -> None:
         daiquiri.setup()

--- a/daiquiri/tests/test_formatter.py
+++ b/daiquiri/tests/test_formatter.py
@@ -28,7 +28,7 @@ class TestColorExtrasFormatter(unittest.TestCase):
         cls.stream = io.StringIO()
         cls.handler = daiquiri.handlers.TTYDetectorStreamHandler(cls.stream)
         cls.logger.logger.addHandler(cls.handler)
-        super(TestColorExtrasFormatter, cls).setUpClass()
+        super().setUpClass()
 
     def setUp(self) -> None:
         # Couldn't get readline() to return anything no matter what I tried, so
@@ -37,7 +37,7 @@ class TestColorExtrasFormatter(unittest.TestCase):
         self.stream.close()
         self.stream = io.StringIO()
         self.handler.stream = self.stream
-        super(TestColorExtrasFormatter, self).setUp()
+        super().setUp()
 
     def test_no_keywords(self) -> None:
         format_string = "%(levelname)s %(name)s%(extras)s: %(message)s"

--- a/daiquiri/tests/test_output.py
+++ b/daiquiri/tests/test_output.py
@@ -21,11 +21,15 @@ import daiquiri
 from daiquiri import output
 
 
-class DatadogMatcher(object):
+class DatadogMatcher:
     def __init__(self, expected: typing.Any) -> None:
         self.expected = expected
 
-    def __eq__(self, other: typing.Any) -> bool:
+    def __eq__(self, other: object) -> bool:
+        # The matcher is only ever compared to the payload handed to
+        # socket.sendall(), i.e. a JSON line as bytes.
+        if not isinstance(other, bytes):
+            return NotImplemented
         return bool(json.loads(other.decode()[:-1]) == self.expected)
 
     def __repr__(self) -> str:
@@ -125,7 +129,9 @@ class TestOutput(unittest.TestCase):
                 },
             }
             try:
-                1 / 0
+                # The useless expression is the point: it is the cheapest way
+                # to get a real traceback for logger.exception() to render.
+                1 / 0  # noqa: B018
             except ZeroDivisionError:
                 logger = daiquiri.getLogger("saymyname")
                 logger.exception("backtrace")

--- a/daiquiri/types.py
+++ b/daiquiri/types.py
@@ -1,5 +1,4 @@
 import logging
-import typing
 
 
 class ColoredLogRecord(logging.LogRecord):
@@ -11,7 +10,7 @@ class ExtrasLogRecord(logging.LogRecord):
     extras_prefix: str
     extras_suffix: str
     extras: str
-    _daiquiri_extra_keys: typing.Set[str]
+    _daiquiri_extra_keys: set[str]
 
 
 class TTYDetectionLogRecord(logging.LogRecord):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,12 @@ raw-options.tag_regex = "^(?P<version>\\d+(?:\\.\\d+)*)$"
 [tool.poe]
 include = ["poe.toml"]
 
+[tool.ruff.lint.per-file-ignores]
+# The examples are deliberately minimal: raising a bare Exception (TRY002) is
+# how you show an exception escaping to the excepthook without inventing an
+# exception class that has nothing to do with what the snippet demonstrates.
+"examples/*" = ["TRY002"]
+
 [tool.mypy]
 files = "daiquiri"
 show_error_codes = true
@@ -71,6 +77,6 @@ requires-dist = []
 dev = [
     "pytest>=6.2.5",
     "poethepoet>=0.21,<0.49",
-    "ruff>=0.15.6",
+    "ruff>=0.16",
     "mypy>=1.18.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ dev = [
     { name = "mypy", specifier = ">=1.18.2" },
     { name = "poethepoet", specifier = ">=0.21,<0.49" },
     { name = "pytest", specifier = ">=6.2.5" },
-    { name = "ruff", specifier = ">=0.15.6" },
+    { name = "ruff", specifier = ">=0.16" },
 ]
 
 [[package]]
@@ -102,7 +102,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -426,27 +426,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.22"
+version = "0.16.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063, upload-time = "2026-07-16T15:14:13.244Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/25/7113f6d5498888c5fb7db34081cba7d5971c4cb1bfb26819966eee68f003/ruff-0.16.1.tar.gz", hash = "sha256:fedad7c801dabd3fb9741d76aca39246e6ddd9ca446a015875207bf19f1e6bc7", size = 4877500, upload-time = "2026-07-30T19:37:01.379Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258, upload-time = "2026-07-16T15:13:19.452Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477, upload-time = "2026-07-16T15:13:23.318Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716, upload-time = "2026-07-16T15:13:26.162Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644, upload-time = "2026-07-16T15:13:29.229Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719, upload-time = "2026-07-16T15:13:32.35Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494, upload-time = "2026-07-16T15:13:35.958Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370, upload-time = "2026-07-16T15:13:39.185Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098, upload-time = "2026-07-16T15:13:42.132Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422, upload-time = "2026-07-16T15:13:45.2Z" },
-    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683, upload-time = "2026-07-16T15:13:48.46Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295, upload-time = "2026-07-16T15:13:51.655Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640, upload-time = "2026-07-16T15:13:54.79Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077, upload-time = "2026-07-16T15:13:57.915Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980, upload-time = "2026-07-16T15:14:01.032Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
-    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/694da69368e0973de65df2ddc73ab18d43c469d5963d9b150911de6bc513/ruff-0.16.1-py3-none-linux_armv6l.whl", hash = "sha256:58edb313b88f0c5460a26adf5f39a37a3be789494a15e3e411e35fa78b89f9a0", size = 10839126, upload-time = "2026-07-30T19:36:13.697Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f0/b626e5d5bd0dd9576263658ef12885e2288afd1029a48e26ffed65ec1ac1/ruff-0.16.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fde5a99e2f97479af66edd6622c6d5a2a7592c77cf4153d9e4428f5eeb55b60c", size = 11070253, upload-time = "2026-07-30T19:36:17.14Z" },
+    { url = "https://files.pythonhosted.org/packages/83/63/f40acfb6b35b88623e71684942b552c3edd96035f5d98f313815f7b277de/ruff-0.16.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e0d4c20532fca4f7fa609369161d968dd28f65d83dabbd61d8e9c7edbf7001f6", size = 10561425, upload-time = "2026-07-30T19:36:20.04Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/14ec0e9c2b4d315547dd38765004b4863e354e1b52cb308272215d9f6f6d/ruff-0.16.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30affbcedf59ad5703d9c91f82266e02b47739f797e1a7b6e158e5526a6dae38", size = 10948879, upload-time = "2026-07-30T19:36:22.476Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e9/9d870cbae575030fdef595f04b4b97573c525b5497cce4f4498cf2f85446/ruff-0.16.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24e9c631573cbca9d20f1283f8f479b2afa4a8503504822bd71a293889f16743", size = 10643691, upload-time = "2026-07-30T19:36:24.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/09/12743d544e2173f53ecd27217c65f90d2bc0f8424a66a60339e56bbc0457/ruff-0.16.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b41bdd48fb420987a9b5212e4957c26ad4abce401fa9ea9d4d85843727945f4f", size = 11435354, upload-time = "2026-07-30T19:36:28.447Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/89/a1652b2daee52083c9554a6333b678a8b01d0400f976827bb87857f9449a/ruff-0.16.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b0d1e1393b7648079e13669de1c1f4fde06d4583e84d8fd5c1551e0a77a2aa75", size = 12259033, upload-time = "2026-07-30T19:36:31.326Z" },
+    { url = "https://files.pythonhosted.org/packages/16/96/ecdcb8c54ee7b123b487f807eb014e6e019155a0b81dfb669acd52f28ce3/ruff-0.16.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:07bf434b1c95f4e093be4532068ef4fcf00924eb2ade8796075980902d6fd54a", size = 11667981, upload-time = "2026-07-30T19:36:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/90/c52e12e0d862e9572f2a33aa227409143520abe53111e9a6babbac7b4af8/ruff-0.16.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39897739f112253ee4fdd2e8aa9a4f9ded99fb2be367d5f31dfa4ded6025584c", size = 11468183, upload-time = "2026-07-30T19:36:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6b/4ffb7ad1d83eb16cf8cbb3c8815d3f11c88460fd162d4b372a2059be1c2a/ruff-0.16.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82ae3c0c0d74daf17b968a10b7b3bb3ef297ab7de0c1f749646b25e690ccb150", size = 11470071, upload-time = "2026-07-30T19:36:39.91Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/32ae7db4c0b5e32ab611787caa19d1546800676d79f7483b7100a3561bf4/ruff-0.16.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4d5f2ed10f8242d83fc08d521301089364e3375375705356f20c0e31606ef3ef", size = 10919503, upload-time = "2026-07-30T19:36:42.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/3d901ba6ad6fc38da39c3448fc6c59ac945679293a17c3ceb6d6c1cba13e/ruff-0.16.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a4665b309891f83f3e3c25447935f1213e9abbd4b5640af7a1f2def9f8d413c1", size = 10649861, upload-time = "2026-07-30T19:36:45.18Z" },
+    { url = "https://files.pythonhosted.org/packages/92/79/894ef1ced26552d5f8c9cf6d85b0687840e1128c55aeab7b9c2d54a0d880/ruff-0.16.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26e9ca5c9bc3971f20d3cf18a957f52ffd6a5f6564ff15c4912a144dcac22494", size = 11148137, upload-time = "2026-07-30T19:36:47.936Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/69/3609a09fa1cb46cc28b762363e440a354204e5dff01bd0c8d7437874d6b9/ruff-0.16.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:67e1e1e3fa4f0c82f0e36d4cd61e661f6e7a6196cb1aa92fe0828fa7b8f257cd", size = 11559211, upload-time = "2026-07-30T19:36:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8a/fb22af2fd78a736e241fabf67e30ce1799a64244026377a49e133af90762/ruff-0.16.1-py3-none-win32.whl", hash = "sha256:d31765e131295b8445caf301e3e8a85b34d1b9b211b4109b7ba457888b051806", size = 10838258, upload-time = "2026-07-30T19:36:53.298Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/35/e57fd9fb5d423961df087a00b12d42c0a830288dc2f3b45ecca299158b4f/ruff-0.16.1-py3-none-win_amd64.whl", hash = "sha256:09b05e8b90c2cb06ad63464350e7a45e8e44a2dfe52072ebfba6666ca8d3f596", size = 11961111, upload-time = "2026-07-30T19:36:56.107Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/240ea004bf6dc4feb40e9832f2205a476a47dd5b8a3f8211a5fc5f95e20e/ruff-0.16.1-py3-none-win_arm64.whl", hash = "sha256:dbaadaac38c70239f056d306b7476f246b0bf000fa6b3876402acbf5b227eaf8", size = 11309414, upload-time = "2026-07-30T19:36:58.79Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Ruff 0.16 promotes hundreds of rules into the default set (413, up from
59), so the bump alone left `ruff check .` with 79 errors and every
`test (3.10…3.14)` job red. This lands the bump together with the code
it now demands. Supersedes #250, which bumped the lockfile only.

Mechanical, from `ruff check --fix`:

- `typing.Optional[X]` / `typing.Union[X, Y]` -> `X | None` / `X | Y`,
  and `typing.Tuple`/`Dict`/`Set`/`Type` -> the builtin generics
  (UP006, UP007, UP045). The floor is 3.10, so these are all runtime-safe.
- `super(Class, self)` -> `super()` (UP008). In `ExtrasFormatter.format`
  the zero-arg form resolves against `__class__`, i.e. exactly the same
  MRO entry as before — the cooperative dispatch that
  `ColorExtrasFormatter` relies on is unchanged.
- `"...".format()` -> f-string (UP032), the stale `# -*- coding: utf-8 -*-`
  dropped (UP009), import blocks sorted (I001).
- `logging.WARN` -> `logging.WARNING` (LOG009); same value, 30.

None of the `%`-formatting rewrites touch a logging call: daiquiri's
lazy-logging call sites pass their arguments to the logger rather than
formatting them, so ruff never saw a `%` operator to rewrite. The two it
did rewrite are `raise` messages.

By hand:

- `ColorFormatter.LEVEL_COLORS` is now `typing.ClassVar[dict[int, str]]`
  (RUF012). It was always meant to be shared class state.
- `DatadogMatcher.__eq__` takes `object` (PYI032) and returns
  `NotImplemented` for anything that is not the bytes payload it matches.
- `1 / 0` in the Datadog test keeps a `# noqa: B018`: the useless
  expression is the point, it is how the test gets a real traceback for
  `logger.exception()` to render.
- `examples/*` ignores TRY002 in the ruff config. The snippet raising a
  bare `Exception` is demonstrating an exception escaping to the
  excepthook; inventing an exception class there would only obscure it.

The dev floor moves to `ruff>=0.16` so a contributor without the lockfile
gets the linter the code was written against.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>