### PR TITLE
fix: support colored output on Windows

### DIFF
--- a/daiquiri/__init__.py
+++ b/daiquiri/__init__.py
@@ -71,6 +71,25 @@ def getLogger(name: str | None = None, **kwargs: typing.Any) -> KeywordArgumentA
     return KeywordArgumentAdapter(logging.getLogger(name), kwargs)
 
 
+def _fix_windows_console() -> None:
+    if sys.platform != "win32":
+        return
+
+    try:
+        import colorama
+    except ImportError:
+        return
+
+    stdout = sys.stdout
+    stderr = sys.stderr
+    colorama.just_fix_windows_console()
+
+    if sys.stdout is not stdout:
+        output.STDOUT.handler.setStream(sys.stdout)
+    if sys.stderr is not stderr:
+        output.STDERR.handler.setStream(sys.stderr)
+
+
 def setup(
     level: int | str = logging.WARNING,
     outputs: typing.Iterable[output.Output | str] = [output.STDERR],
@@ -87,6 +106,7 @@ def setup(
     :param program_name: The name of the program. Auto-detected if not set.
     :param capture_warnings: Capture warnings from the `warnings` module.
     """
+    _fix_windows_console()
     root_logger = logging.getLogger(None)
 
     # Remove all handlers

--- a/daiquiri/output.py
+++ b/daiquiri/output.py
@@ -220,6 +220,8 @@ class TimedRotatingFile(Output):
 class Stream(Output):
     """Generic stream output."""
 
+    handler: handlers.TTYDetectorStreamHandler
+
     def __init__(
         self,
         stream: typing.TextIO = sys.stderr,

--- a/daiquiri/tests/test_daiquiri.py
+++ b/daiquiri/tests/test_daiquiri.py
@@ -17,6 +17,7 @@ import types
 import typing
 import unittest
 import warnings
+from unittest import mock
 
 import daiquiri
 
@@ -35,6 +36,35 @@ class TestDaiquiri(unittest.TestCase):
         daiquiri.setup()
         daiquiri.setup(level=logging.DEBUG)
         daiquiri.setup(program_name="foobar")
+
+    def test_setup_fixes_windows_console(self) -> None:
+        original_stderr = sys.stderr
+        original_stream = daiquiri.output.STDERR.handler.stream
+        wrapped_stderr = io.StringIO()
+
+        def just_fix_windows_console() -> None:
+            sys.stderr = wrapped_stderr
+
+        colorama = types.ModuleType("colorama")
+        colorama.__dict__["just_fix_windows_console"] = just_fix_windows_console
+
+        try:
+            with (
+                mock.patch.object(sys, "platform", "win32"),
+                mock.patch.dict(sys.modules, {"colorama": colorama}),
+            ):
+                daiquiri.setup(outputs=(), capture_warnings=False, set_excepthook=False)
+                self.assertIs(daiquiri.output.STDERR.handler.stream, wrapped_stderr)
+        finally:
+            sys.stderr = original_stderr
+            daiquiri.output.STDERR.handler.setStream(original_stream)
+
+    def test_setup_without_colorama(self) -> None:
+        with (
+            mock.patch.object(sys, "platform", "win32"),
+            mock.patch("builtins.__import__", side_effect=ImportError),
+        ):
+            daiquiri.setup(outputs=(), capture_warnings=False, set_excepthook=False)
 
     def test_excepthook(self) -> None:
         hook_ran = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 homepage = "https://github.com/Mergifyio/daiquiri"
 
 [project.optional-dependencies]
+colorama = ["colorama>=0.4.6; sys_platform == 'win32'"]
 systemd = ["systemd-python>=234; sys_platform == 'linux'"]
 
 [tool.hatch.version]
@@ -55,6 +56,7 @@ strict = true
 
 [[tool.mypy.overrides]]
 module = [
+       "colorama",
        "systemd",
 ]
 ignore_missing_imports = true

--- a/uv.lock
+++ b/uv.lock
@@ -70,6 +70,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+colorama = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
 systemd = [
     { name = "systemd-python", marker = "sys_platform == 'linux'" },
 ]
@@ -84,10 +87,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "colorama", marker = "sys_platform == 'win32' and extra == 'colorama'", specifier = ">=0.4.6" },
     { name = "python-json-logger", specifier = ">=3" },
     { name = "systemd-python", marker = "sys_platform == 'linux' and extra == 'systemd'", specifier = ">=234" },
 ]
-provides-extras = ["systemd"]
+provides-extras = ["colorama", "systemd"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Fixes #17.

Adds Colorama as an optional extra on Windows and initializes it during `setup()`. The preconfigured stdout and stderr handlers follow Colorama's wrapped streams when needed.

Tested on Windows with Colorama 0.4.6. Added coverage for wrapped console streams and installs without the extra.